### PR TITLE
There is a small bug with npm run dev.

### DIFF
--- a/scripts/dev.sh
+++ b/scripts/dev.sh
@@ -1,2 +1,13 @@
 #!/usr/bin/env bash
+
+set -e
+
+#This silences the terminal while the docker is being pulled down
+cleanup() {
+    docker_compose_pid > /dev/null 2>&1
+    trap '' EXIT INT TERM
+    exit $err
+}	
+
 docker-compose -f docker-compose.dev.yml up --force-recreate --remove-orphans
+docker_compose_pid=$!


### PR DESCRIPTION
The terminal would not line break after ending the script early. I added a clean up function to fix this